### PR TITLE
Java Plugin :  avoid the use of "-impl" class and translate french texts

### DIFF
--- a/sonarqube-plugin-greenit/docker-compose.yml
+++ b/sonarqube-plugin-greenit/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         source: ./native-analyzer/python-plugin/target/python-plugin-1.0.0-SNAPSHOT.jar
         target: /opt/sonarqube/extensions/plugins/python-plugin-1.0.0-SNAPSHOT.jar
       - type: bind
-        source: /home/gael/IdeaProjects/myCustomPlugin/js-linter/eslint-report.json
+        source: ./native-analyzer/eslint-report.json
         target: /opt/reports/eslint-report.json
       # - "conf:/opt/sonarqube/conf"
       - "extensions:/opt/sonarqube/extensions"
@@ -64,11 +64,14 @@ services:
         target: /opt/project/sonar-project.properties
       - "/home/gael/IdeaProjects/sonar-custom-plugin-example/scripts:/opt/scripts"
       - type: bind
-        source: /home/gael/IdeaProjects/myCustomPlugin/js-linter/eslint-report.json
+        source: ./native-analyzer/eslint-report.json
         target: /opt/project/eslint-report.json
       - type: bind
-        source: /home/gael/IdeaProjects/myCustomPlugin/css-linter/stylelint-report.json
+        source: ./native-analyzer/stylelint-report.json
         target: /opt/project/stylelint-report.json
+      - type: bind
+        source: ./native-analyzer/
+        target: /opt/project/native-analyzer/
 
 networks:
   sonarnet:

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/AvoidTryCatchFinallyCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/AvoidTryCatchFinallyCheck.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Rule(
         key = "S34",
         name = "Developpement",
-        description = "Eviter d'utiliser try-catch-finally",
+        description = "Avoid the use of try-catch-finally",
         priority = Priority.MINOR,
         tags = {"bug"})
 public class AvoidTryCatchFinallyCheck extends IssuableSubscriptionVisitor {
@@ -24,7 +24,7 @@ public class AvoidTryCatchFinallyCheck extends IssuableSubscriptionVisitor {
     @Override
     public void visitNode(Tree tree) {
         TryStatementTree tryStatementTree = (TryStatementTree) tree;
-            reportIssue(tree, "Eviter d'utiliser try-catch-finally");
+            reportIssue(tree, "Avoid the use of try-catch-finally");
 
     }
 }

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/AvoidTryCatchFinallyCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/AvoidTryCatchFinallyCheck.java
@@ -3,28 +3,71 @@ package fr.cnumr.java.checks;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Symbol.MethodSymbol;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TryStatementTree;
 
 import java.util.Collections;
 import java.util.List;
 
-@Rule(
-        key = "S34",
-        name = "Developpement",
-        description = "Avoid the use of try-catch-finally",
-        priority = Priority.MINOR,
-        tags = {"bug"})
+@Rule(key = "S34", 
+		name = "Developpement", 
+		description = "Avoid the use of try-catch-finally when not needed", 
+		priority = Priority.MINOR, 
+		tags = {"bug" })
+
 public class AvoidTryCatchFinallyCheck extends IssuableSubscriptionVisitor {
-    @Override
-    public List<Tree.Kind> nodesToVisit() {
-        return Collections.singletonList(Tree.Kind.TRY_STATEMENT);
-    }
 
-    @Override
-    public void visitNode(Tree tree) {
-        TryStatementTree tryStatementTree = (TryStatementTree) tree;
-            reportIssue(tree, "Avoid the use of try-catch-finally");
+	private final AvoidTryCatchFinallyCheckVisitor visitor = new AvoidTryCatchFinallyCheckVisitor();
 
-    }
+	@Override
+	public List<Tree.Kind> nodesToVisit() {
+		return Collections.singletonList(Tree.Kind.TRY_STATEMENT);
+	}
+
+	@Override
+	public void visitNode(Tree tree) {
+		if (!visitor.containsThrowsException((TryStatementTree) tree)) {
+			reportIssue(tree, "Avoid the use of try-catch-finally when not needed");
+		}
+	}
+
+	private class AvoidTryCatchFinallyCheckVisitor extends BaseTreeVisitor {
+
+		private boolean isThrowingException;
+
+		public boolean containsThrowsException(TryStatementTree tree) {
+			isThrowingException = false;
+			tree.block().accept(visitor);
+			return isThrowingException;
+		}
+
+		@Override
+		public void visitMethodInvocation(MethodInvocationTree tree) {
+			if (isThrowingException(tree.symbol())) {
+				return;
+			}
+			super.visitMethodInvocation(tree);
+		}
+
+		@Override
+		public void visitNewClass(NewClassTree tree) {
+			if (isThrowingException(tree.constructorSymbol())) {
+				return;
+			}
+			super.visitNewClass(tree);
+		}
+
+		private boolean isThrowingException(Symbol symbol) {
+			isThrowingException |= symbol.isUnknown() || ((MethodSymbol) symbol).thrownTypes().size() > 0;
+
+			return isThrowingException;
+
+		}
+	}
+
 }

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/IncrementCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/IncrementCheck.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Rule(
         key = "S67",
         name = "Developpement",
-        description = "Remplacer les $i++ par ++$i",
+        description = "Use ++i instead of i++",
         priority = Priority.MINOR,
         tags = {"bug"})
 public class IncrementCheck extends IssuableSubscriptionVisitor {
@@ -26,6 +26,6 @@ public class IncrementCheck extends IssuableSubscriptionVisitor {
     @Override
     public void visitNode(Tree tree) {
         UnaryExpressionTree method = (UnaryExpressionTree) tree;
-        reportIssue(tree, "Never do that!");
+        reportIssue(tree, "Use ++i instead of i++");
     }
 }

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/NoFunctionCallWhenDeclaringForLoop.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/java/fr/cnumr/java/checks/NoFunctionCallWhenDeclaringForLoop.java
@@ -109,8 +109,11 @@ public class NoFunctionCallWhenDeclaringForLoop extends IssuableSubscriptionVisi
 		public void visitMethodInvocation(MethodInvocationTree tree) {
 			if (!lineAlreadyHasThisIssue(tree)) {
 				repport(tree);
+				return;
 			}
+			super.visitMethodInvocation(tree);
 		}
+		
 	    private boolean lineAlreadyHasThisIssue(Tree tree) {
 	        if (tree.firstToken() != null) {
 	            final String classname = getFullyQualifiedNameOfClassOf(tree);

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.html
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.html
@@ -1,4 +1,4 @@
-<p>Eviter d'utiliser try-catch-finally</p>
+<p>Avoid the use of try-catch-finally</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
         try {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.html
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.html
@@ -1,23 +1,18 @@
-<p>Avoid the use of try-catch-finally</p>
+<p>Avoid the use of try-catch-finally when not needed</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
         try {
-            .....
+            int i = 0;
+            System.out.println((char) i); //println() doesn't send an Exception
             }
         } catch (IOException e) {
-            .......
+            ....... //never reach
         } finally {
-            ......
+            ...... //never reach
         }
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
-
-        try {
-            .....
-            }
-        } catch (IOException e) {
-            .......
-        }
-
+        int i = 0;
+        System.out.println((char) i);
 </pre>

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.json
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.json
@@ -1,5 +1,5 @@
 {
-  "title": "Avoid the use of try-catch-finally",
+  "title": "Avoid the use of try-catch-finally when not needed",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.json
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S34.json
@@ -1,5 +1,5 @@
 {
-  "title": "Eviter d'utiliser try-catch-finally",
+  "title": "Avoid the use of try-catch-finally",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S67.html
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S67.html
@@ -1,7 +1,7 @@
-<p>Remplacer les $i++ par ++$i</p>
+<p>Use ++i instead of i++</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
-$i++
+i++
 </pre>
 <h2>Compliant Solution</h2>
-<pre>++$i</pre>
+<pre>++i</pre>

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S67.json
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S67.json
@@ -1,5 +1,5 @@
 {
-  "title": "Remplacer les $i++ par ++$i",
+  "title": "Use ++i instead of i++",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S69.html
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S69.html
@@ -1,4 +1,4 @@
-<p>Ne pas appeler de fonction dans la déclaration d’une boucle de type for</p>
+<p>Do not call a function in the declaration of a for-type loop</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
     public void foo() {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S69.json
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/main/resources/fr/cnumr/l10n/java/rules/java/S69.json
@@ -1,5 +1,5 @@
 {
-  "title": "Ne pas appeler de fonction dans la déclaration d’une boucle de type for",
+  "title": "Do not call a function in the declaration of a for-type loop",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/files/AvoidTryCatchFinallyCheck.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/files/AvoidTryCatchFinallyCheck.java
@@ -3,57 +3,92 @@ import java.io.FileReader;
 import java.io.IOException;
 
 class AvoidTryCatchFinallyCheck {
-    AvoidTryCatchFinallyCheck(AvoidTryCatchFinallyCheck mc) {
-    }
+	AvoidTryCatchFinallyCheck(AvoidTryCatchFinallyCheck mc) {
+	}
 
-    public void openFileWithFInally() {
-        FileReader reader = null;
-        try { // Noncompliant
-            reader = new FileReader("someFile");
-            int i = 0;
-            while (i != -1) {
-                i = reader.read();
-                System.out.println((char) i);
-            }
-        } catch (IOException e) {
-            //do something clever with the exception
-        } finally {
-            if (reader != null) {
-                try { // Noncompliant
-                    reader.close();
-                } catch (IOException e) {
-                    //do something clever with the exception
-                }
-            }
-            System.out.println("--- File End ---");
-        }
-    }
+	public void openFileWithFInally() {
+		FileReader reader = null;
+		try {
+			reader = new FileReader("someFile");
+			int i = 0;
+			while (i != -1) {
+				i = reader.read();
+				System.out.println((char) i);
+			}
+		} catch (IOException e) {
+			// do something clever with the exception
+		} finally {
+			if (reader != null) {
+				try {
+					reader.close();
+				} catch (IOException e) {
+					// do something clever with the exception
+				}
+			}
+			System.out.println("--- File End ---");
+		}
+	}
 
+	public void openFileWithoutFInally() {
+		FileReader reader = null;
+		try {
+			reader = new FileReader("someFile");
+			int i = 0;
+			while (i != -1) {
+				i = reader.read();
+				System.out.println((char) i);
+			}
+		} catch (IOException e) {
+			// do something clever with the exception
+		} finally {
+			if (reader != null) {
+				try {// Noncompliant
+					int i = 0;
+				} catch (IOException e) {
+					// do something clever with the exception
+				}
+			}
+			System.out.println("--- File End ---");
+		}
+	}
 
-    public void openFileWithoutFInally() {
-        FileReader reader = null;
-        try { // Noncompliant
-            reader = new FileReader("someFile");
-            int i = 0;
-            while (i != -1) {
-                i = reader.read();
-                System.out.println((char) i);
-            }
-        } catch (IOException e) {
-            //do something clever with the exception
-        }
-    }
+	public void openFileWithoutTryCatch() throws IOException {
+		FileReader reader = null;
+		reader = new FileReader("someFile");
+		int i = 0;
+		while (i != -1) {
+			i = reader.read();
+			System.out.println((char) i);
+		}
 
+	}
 
-    public void openFileWithoutTryCatch() throws IOException {
-        FileReader reader = null;
-        reader = new FileReader("someFile");
-        int i = 0;
-        while (i != -1) {
-            i = reader.read();
-            System.out.println((char) i);
-        }
+	public void openWithException() {
+		try {
+			openFileWithoutTryCatch();
+		} catch (IOException e) {
+			FileReader reader = new FileReader("someFile");
+			reader.close();
+		}
+	}
 
-    }
+	public void openTryWithNoException() {
+		try { // Noncompliant
+			int i = 0;
+			System.out.println((char) i);
+		} catch (IOException e) {
+			// do something clever with the exception
+		}
+	}
+
+	public void openTryWithNoMethod() {
+
+		try { // Noncompliant
+			int i = 0;
+
+		} catch (IOException e) {
+			// do something clever with the exception
+		}
+	}
 
 }

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
@@ -52,4 +52,5 @@ class NoFunctionCallWhenDeclaringForLoop {
             boolean b = getMyValue() > 6;
         }
     }
+
 }

--- a/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/java/fr/cnumr/java/MyJavaRulesDefinitionTest.java
+++ b/sonarqube-plugin-greenit/native-analyzer/java-plugin/src/test/java/fr/cnumr/java/MyJavaRulesDefinitionTest.java
@@ -52,7 +52,7 @@ class MyJavaRulesDefinitionTest {
   private static void assertRuleProperties(Repository repository) {
     Rule rule = repository.rule("S67");
     assertThat(rule).isNotNull();
-    assertThat(rule.name()).isEqualTo("Remplacer les $i++ par ++$i");
+    assertThat(rule.name()).isEqualTo("Use ++i instead of i++");
     assertThat(rule.debtRemediationFunction().type()).isEqualTo(Type.CONSTANT_ISSUE);
     assertThat(rule.type()).isEqualTo(RuleType.CODE_SMELL);
   }

--- a/sonarqube-plugin-greenit/sonar-project.properties
+++ b/sonarqube-plugin-greenit/sonar-project.properties
@@ -16,5 +16,5 @@ sonar.projectKey=sonar-custom-plugin-example
 
 sonar.eslint.reportPaths=/opt/project/eslint-report.json
 sonar.css.stylelint.reportPaths=/opt/project/stylelint-report.json
-
+sonar.java.binaries=/opt/project/native-analyzer/java-plugin/target/classes
 sonar.scm.disabled=true


### PR DESCRIPTION
For the java plugin only : 

-The class which are not from the package  org.sonar.plugins.java.api are not avaibble in the classloader during execution, so i remove and use the correct way for the search needed.
-Translate all french texts and messages for a better integration. 